### PR TITLE
Corrigido a variável de ambiente WEB_PORT não funcionando corretamente em diferentes plataformas

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "concurrently \"pnpm dev:web\" \"pnpm dev:api\"",
-    "dev:web": "dotenv -e ./.env -- cross-env PORT=$WEB_PORT pnpm --filter web dev",
+    "dev:web": "dotenv -e ./.env -- node scripts/dev-web.js",
     "dev:api": "dotenv -e ./.env -- pnpm --filter api dev",
     "docker:up": "docker compose up -d postgres_dev nginx_dev",
     "docker:down": "docker compose down",
@@ -14,7 +14,6 @@
   "devDependencies": {
     "@types/node": "^25.6.2",
     "concurrently": "^9.0.0",
-    "cross-env": "^10.1.0",
     "dotenv-cli": "^11.0.0",
     "typescript": "^6.0.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,12 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-catalogs:
-  prisma:
-    prisma:
-      specifier: latest
-      version: 7.8.0
-
 importers:
 
   .:
@@ -20,9 +14,6 @@ importers:
       concurrently:
         specifier: ^9.0.0
         version: 9.2.1
-      cross-env:
-        specifier: ^10.1.0
-        version: 10.1.0
       dotenv-cli:
         specifier: ^11.0.0
         version: 11.0.0
@@ -215,9 +206,6 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
-
-  '@epic-web/invariant@1.0.0':
-    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -1358,11 +1346,6 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-
-  cross-env@10.1.0:
-    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
-    engines: {node: '>=20'}
-    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3059,8 +3042,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@epic-web/invariant@1.0.0': {}
-
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -4076,11 +4057,6 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
-
-  cross-env@10.1.0:
-    dependencies:
-      '@epic-web/invariant': 1.0.0
-      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/scripts/dev-web.js
+++ b/scripts/dev-web.js
@@ -1,0 +1,20 @@
+const { spawn } = require('node:child_process');
+
+const port = process.env.WEB_PORT;
+
+const child = spawn(
+  'pnpm',
+  ['--filter', 'web', 'dev'],
+  {
+    stdio: 'inherit',
+    shell: true,
+    env: {
+      ...process.env,
+      PORT: port,
+    },
+  }
+);
+
+child.on('exit', code => {
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
A solução anterior para fazer com que a variável de ambiente `WEB_PORT` fosse de fato utilizada como porta pelo Next.js não funcionava de forma igual e previsível entre plataformas diferentes (Windows x Linux).

fix #23 