### PR TITLE
Scripts de desenvolvimento para dar e remover permissão de administrador

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "db:generate": "dotenv -e ./.env -- pnpm --filter database db:generate",
     "db:migrate": "dotenv -e ./.env -- pnpm --filter database db:migrate",
     "db:reset": "dotenv -e ./.env -- pnpm --filter database db:reset",
-    "db:studio": "dotenv -e ./.env -- pnpm --filter database db:studio"
+    "db:studio": "dotenv -e ./.env -- pnpm --filter database db:studio",
+    "users": "dotenv -e ./.env -- tsx scripts/users.ts"
   },
   "devDependencies": {
     "@types/node": "^25.6.2",

--- a/scripts/users.ts
+++ b/scripts/users.ts
@@ -1,0 +1,61 @@
+import { prisma } from "../packages/database";
+
+const COMMANDS: Record<string, () => Promise<void>> = {
+  "grant-admin": async () => {
+    const email = process.argv[3];
+
+    if (!email) {
+      console.error("Usage: pnpm grant-admin <email>");
+      process.exit(1);
+    }
+
+    await prisma.user.update({
+      where: {
+        email,
+      },
+      data: {
+        admin: true,
+      },
+    });
+
+    console.log(`${email} is now an administrator.`);
+  },
+
+  "revoke-admin": async () => {
+    const email = process.argv[3];
+
+    if (!email) {
+      console.error("Usage: pnpm revoke-admin <email>");
+      process.exit(1);
+    }
+
+    await prisma.user.update({
+      where: {
+        email,
+      },
+      data: {
+        admin: false,
+      },
+    });
+
+    console.log(`${email} is not an administrator anymore.`);
+  },
+};
+
+(async () => {
+  try {
+    const command = process.argv[2];
+    const fn = COMMANDS[command];
+    if (fn) await fn();
+    else {
+      console.log("Unknown command");
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    await prisma.$disconnect();
+    process.exit();
+  }
+})();


### PR DESCRIPTION
Adiciona os scripts:
- `pnpm users grant-admin <email>`
- `pnpm users revoke-admin <email>`

Permite rapidamente adicionar e remover permissão de administrador a usuários durante o desenvolvimento.