### PR TITLE
Muda o filtro de pesquisa de avaliações para usar a data da visita

### DIFF
--- a/apps/api/src/modules/trails/reviews.service.ts
+++ b/apps/api/src/modules/trails/reviews.service.ts
@@ -39,8 +39,8 @@ export async function getTrailReviews({
   }
 
   const orderConfig = {
-    newest: { field: "updatedAt", direction: "desc" },
-    oldest: { field: "updatedAt", direction: "asc" },
+    newest: { field: "visitDate", direction: "desc" },
+    oldest: { field: "visitDate", direction: "asc" },
     "rating-desc": { field: "rating", direction: "desc" },
     "rating-asc": { field: "rating", direction: "asc" },
     "difficulty-desc": { field: "difficultyRating", direction: "desc" },

--- a/packages/database/prisma/migrations/20260706145712_add_review_search_indexes/migration.sql
+++ b/packages/database/prisma/migrations/20260706145712_add_review_search_indexes/migration.sql
@@ -1,0 +1,8 @@
+-- CreateIndex
+CREATE INDEX "Review_visitDate_id_idx" ON "Review"("visitDate", "id");
+
+-- CreateIndex
+CREATE INDEX "Review_rating_id_idx" ON "Review"("rating", "id");
+
+-- CreateIndex
+CREATE INDEX "Review_difficultyRating_id_idx" ON "Review"("difficultyRating", "id");

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -148,6 +148,9 @@ model Review {
   @@index([trailId])
   @@index([userId])
   @@index([trailId, id(sort: Desc)])
+  @@index([visitDate, id])
+  @@index([rating, id])
+  @@index([difficultyRating, id])
 }
 
 model TrailCollection {


### PR DESCRIPTION
Muda o filtro de pesquisa de avaliações para usar a data da visita ao invés da data de atualização e adiciona índices no banco de dados para uma busca mais rápida.